### PR TITLE
Migrate tests from MSTest to xUnit

### DIFF
--- a/src/Edi.TemplateEmail.Tests/Edi.TemplateEmail.Tests.csproj
+++ b/src/Edi.TemplateEmail.Tests/Edi.TemplateEmail.Tests.csproj
@@ -4,29 +4,23 @@
     <TargetFramework>net9.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
-    <EnableMSTestRunner>true</EnableMSTestRunner>
-    <OutputType>Exe</OutputType>
-    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
-    <!--
-      Displays error on console in addition to the log file. Note that this feature comes with a performance impact.
-      For more information, visit https://learn.microsoft.com/dotnet/core/testing/unit-testing-platform-integration-dotnet-test#show-failure-per-test
-      -->
-    <TestingPlatformShowTestsFailure>true</TestingPlatformShowTestsFailure>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.14.2" />
-    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" Version="1.8.1" />
-    <PackageReference Include="MSTest" Version="3.10.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Edi.TemplateEmail\Edi.TemplateEmail.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
   </ItemGroup>
 
 </Project>

--- a/src/Edi.TemplateEmail.Tests/EmailHelperTests.cs
+++ b/src/Edi.TemplateEmail.Tests/EmailHelperTests.cs
@@ -1,16 +1,15 @@
 using System.Xml.Serialization;
+using Xunit;
 
 namespace Edi.TemplateEmail.Tests;
 
-[TestClass]
-public class EmailHelperTests
+public class EmailHelperTests : IDisposable
 {
-    private EmailSettings _testSettings;
-    private MailConfiguration _testMailConfiguration;
-    private string _testConfigPath;
+    private readonly EmailSettings _testSettings;
+    private readonly MailConfiguration _testMailConfiguration;
+    private readonly string _testConfigPath;
 
-    [TestInitialize]
-    public void TestInitialize()
+    public EmailHelperTests()
     {
         _testSettings = new EmailSettings
         {
@@ -43,8 +42,7 @@ public class EmailHelperTests
         serializer.Serialize(fileStream, _testMailConfiguration);
     }
 
-    [TestCleanup]
-    public void TestCleanup()
+    public void Dispose()
     {
         if (File.Exists(_testConfigPath))
         {
@@ -52,59 +50,59 @@ public class EmailHelperTests
         }
     }
 
-    [TestMethod]
+    [Fact]
     public void Constructor_WithConfiguration_ShouldSetProperties()
     {
         // Act
         var emailHelper = new EmailHelper(_testMailConfiguration, _testSettings);
 
         // Assert
-        Assert.AreEqual(_testSettings, emailHelper.Settings);
-        Assert.IsNull(emailHelper.Engine);
-        Assert.IsNull(emailHelper.Pipeline);
+        Assert.Equal(_testSettings, emailHelper.Settings);
+        Assert.Null(emailHelper.Engine);
+        Assert.Null(emailHelper.Pipeline);
     }
 
-    [TestMethod]
+    [Fact]
     public void Constructor_WithConfigPath_ShouldSetProperties()
     {
         // Act
         var emailHelper = new EmailHelper(_testConfigPath, _testSettings);
 
         // Assert
-        Assert.AreEqual(_testSettings, emailHelper.Settings);
-        Assert.IsNull(emailHelper.Engine);
-        Assert.IsNull(emailHelper.Pipeline);
+        Assert.Equal(_testSettings, emailHelper.Settings);
+        Assert.Null(emailHelper.Engine);
+        Assert.Null(emailHelper.Pipeline);
     }
 
-    [TestMethod]
+    [Fact]
     public void Constructor_WithNullConfigPath_ShouldThrowArgumentNullException()
     {
-        // Act
-        Assert.ThrowsExactly<ArgumentNullException>(() => new EmailHelper((string)null, _testSettings));
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => new EmailHelper((string)null, _testSettings));
     }
 
-    [TestMethod]
+    [Fact]
     public void Constructor_WithEmptyConfigPath_ShouldThrowArgumentNullException()
     {
-        // Act
-        Assert.ThrowsExactly<ArgumentNullException>(() => new EmailHelper(string.Empty, _testSettings));
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => new EmailHelper(string.Empty, _testSettings));
     }
 
-    [TestMethod]
+    [Fact]
     public void Constructor_WithWhitespaceConfigPath_ShouldThrowArgumentNullException()
     {
-        // Act
-        Assert.ThrowsExactly<ArgumentNullException>(() => new EmailHelper("   ", _testSettings));
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => new EmailHelper("   ", _testSettings));
     }
 
-    [TestMethod]
+    [Fact]
     public void Constructor_WithNonExistentConfigPath_ShouldThrowFileNotFoundException()
     {
-        // Act
-        Assert.ThrowsExactly<FileNotFoundException>(() => new EmailHelper("nonexistent.xml", _testSettings));
+        // Act & Assert
+        Assert.Throws<FileNotFoundException>(() => new EmailHelper("nonexistent.xml", _testSettings));
     }
 
-    [TestMethod]
+    [Fact]
     public void ForType_ShouldSetMailTypeAndCreatePipeline()
     {
         // Arrange
@@ -115,11 +113,11 @@ public class EmailHelperTests
         var result = emailHelper.ForType(mailType);
 
         // Assert
-        Assert.AreSame(emailHelper, result); // Should return self for fluent interface
-        Assert.IsNotNull(emailHelper.Pipeline);
+        Assert.Same(emailHelper, result); // Should return self for fluent interface
+        Assert.NotNull(emailHelper.Pipeline);
     }
 
-    [TestMethod]
+    [Fact]
     public void Map_ShouldAddValueToPipeline()
     {
         // Arrange
@@ -132,12 +130,12 @@ public class EmailHelperTests
         var result = emailHelper.Map(name, value);
 
         // Assert
-        Assert.AreSame(emailHelper, result); // Should return self for fluent interface
-        Assert.IsTrue(emailHelper.Pipeline.HasEntity(name));
-        Assert.AreEqual(value, emailHelper.Pipeline[name].Value);
+        Assert.Same(emailHelper, result); // Should return self for fluent interface
+        Assert.True(emailHelper.Pipeline.HasEntity(name));
+        Assert.Equal(value, emailHelper.Pipeline[name].Value);
     }
 
-    [TestMethod]
+    [Fact]
     public void MapRange_ShouldAddMultipleValuesToPipeline()
     {
         // Arrange
@@ -154,16 +152,16 @@ public class EmailHelperTests
         var result = emailHelper.MapRange(values);
 
         // Assert
-        Assert.AreSame(emailHelper, result); // Should return self for fluent interface
-        Assert.IsTrue(emailHelper.Pipeline.HasEntity("Name1"));
-        Assert.IsTrue(emailHelper.Pipeline.HasEntity("Name2"));
-        Assert.IsTrue(emailHelper.Pipeline.HasEntity("Name3"));
-        Assert.AreEqual("Value1", emailHelper.Pipeline["Name1"].Value);
-        Assert.AreEqual(42, emailHelper.Pipeline["Name2"].Value);
-        Assert.AreEqual(true, emailHelper.Pipeline["Name3"].Value);
+        Assert.Same(emailHelper, result); // Should return self for fluent interface
+        Assert.True(emailHelper.Pipeline.HasEntity("Name1"));
+        Assert.True(emailHelper.Pipeline.HasEntity("Name2"));
+        Assert.True(emailHelper.Pipeline.HasEntity("Name3"));
+        Assert.Equal("Value1", emailHelper.Pipeline["Name1"].Value);
+        Assert.Equal(42, emailHelper.Pipeline["Name2"].Value);
+        Assert.Equal(true, emailHelper.Pipeline["Name3"].Value);
     }
 
-    [TestMethod]
+    [Fact]
     public void MapRange_WithNoValues_ShouldReturnSelf()
     {
         // Arrange
@@ -174,10 +172,10 @@ public class EmailHelperTests
         var result = emailHelper.MapRange();
 
         // Assert
-        Assert.AreSame(emailHelper, result);
+        Assert.Same(emailHelper, result);
     }
 
-    [TestMethod]
+    [Fact]
     public void BuildMessage_WithValidReceipts_ShouldReturnCommonMailMessage()
     {
         // Arrange
@@ -193,17 +191,17 @@ public class EmailHelperTests
         var result = emailHelper.BuildMessage(receipts, ccReceipts);
 
         // Assert
-        Assert.IsNotNull(result);
-        Assert.IsInstanceOfType(result, typeof(CommonMailMessage));
-        Assert.AreSame(receipts, result.Receipts);
-        Assert.AreSame(ccReceipts, result.CcReceipts);
-        Assert.AreSame(_testSettings, result.Settings);
-        Assert.IsNotNull(result.Subject);
-        Assert.IsNotNull(result.Body);
-        Assert.IsTrue(result.BodyIsHtml);
+        Assert.NotNull(result);
+        Assert.IsType<CommonMailMessage>(result);
+        Assert.Same(receipts, result.Receipts);
+        Assert.Same(ccReceipts, result.CcReceipts);
+        Assert.Same(_testSettings, result.Settings);
+        Assert.NotNull(result.Subject);
+        Assert.NotNull(result.Body);
+        Assert.True(result.BodyIsHtml);
     }
 
-    [TestMethod]
+    [Fact]
     public void BuildMessage_WithOnlyReceipts_ShouldReturnCommonMailMessage()
     {
         // Arrange
@@ -218,35 +216,35 @@ public class EmailHelperTests
         var result = emailHelper.BuildMessage(receipts);
 
         // Assert
-        Assert.IsNotNull(result);
-        Assert.AreSame(receipts, result.Receipts);
-        Assert.IsNull(result.CcReceipts);
-        Assert.AreSame(_testSettings, result.Settings);
+        Assert.NotNull(result);
+        Assert.Same(receipts, result.Receipts);
+        Assert.Null(result.CcReceipts);
+        Assert.Same(_testSettings, result.Settings);
     }
 
-    [TestMethod]
+    [Fact]
     public void BuildMessage_WithNullReceipts_ShouldThrowArgumentNullException()
     {
         // Arrange
         var emailHelper = new EmailHelper(_testMailConfiguration, _testSettings);
         emailHelper.ForType("TestMail");
 
-        // Act
-        Assert.ThrowsExactly<ArgumentNullException>(() => emailHelper.BuildMessage(null));
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => emailHelper.BuildMessage(null));
     }
 
-    [TestMethod]
+    [Fact]
     public void BuildMessage_WithEmptyReceipts_ShouldThrowArgumentNullException()
     {
         // Arrange
         var emailHelper = new EmailHelper(_testMailConfiguration, _testSettings);
         emailHelper.ForType("TestMail");
 
-        // Act
-        Assert.ThrowsExactly<ArgumentNullException>(() => emailHelper.BuildMessage(new string[0]));
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => emailHelper.BuildMessage(new string[0]));
     }
 
-    [TestMethod]
+    [Fact]
     public void FluentInterface_ShouldWorkCorrectly()
     {
         // Arrange
@@ -264,14 +262,14 @@ public class EmailHelperTests
             .BuildMessage(receipts);
 
         // Assert
-        Assert.IsNotNull(result);
-        Assert.IsInstanceOfType(result, typeof(CommonMailMessage));
-        Assert.IsTrue(emailHelper.Pipeline.HasEntity("MachineName"));
-        Assert.IsTrue(emailHelper.Pipeline.HasEntity("SmtpServer"));
-        Assert.IsTrue(emailHelper.Pipeline.HasEntity("Port"));
+        Assert.NotNull(result);
+        Assert.IsType<CommonMailMessage>(result);
+        Assert.True(emailHelper.Pipeline.HasEntity("MachineName"));
+        Assert.True(emailHelper.Pipeline.HasEntity("SmtpServer"));
+        Assert.True(emailHelper.Pipeline.HasEntity("Port"));
     }
 
-    [TestMethod]
+    [Fact]
     public void Engine_ShouldBeSetAfterBuildMessage()
     {
         // Arrange
@@ -286,11 +284,11 @@ public class EmailHelperTests
         emailHelper.BuildMessage(receipts);
 
         // Assert
-        Assert.IsNotNull(emailHelper.Engine);
-        Assert.IsInstanceOfType(emailHelper.Engine, typeof(TemplateEngine));
+        Assert.NotNull(emailHelper.Engine);
+        Assert.IsType<TemplateEngine>(emailHelper.Engine);
     }
 
-    [TestMethod]
+    [Fact]
     public void BuildMessage_ShouldTrimSubjectAndBody()
     {
         // Arrange
@@ -317,11 +315,11 @@ public class EmailHelperTests
         var result = emailHelper.BuildMessage(receipts);
 
         // Assert
-        Assert.AreEqual("Test Subject", result.Subject);
-        Assert.AreEqual("Test Body", result.Body);
+        Assert.Equal("Test Subject", result.Subject);
+        Assert.Equal("Test Body", result.Body);
     }
 
-    [TestMethod]
+    [Fact]
     public void BuildMessage_ShouldSetBodyIsHtmlFromConfiguration()
     {
         // Arrange
@@ -362,7 +360,7 @@ public class EmailHelperTests
         var textResult = emailHelperText.ForType("TextMail").BuildMessage(receipts);
 
         // Assert
-        Assert.IsTrue(htmlResult.BodyIsHtml);
-        Assert.IsFalse(textResult.BodyIsHtml);
+        Assert.True(htmlResult.BodyIsHtml);
+        Assert.False(textResult.BodyIsHtml);
     }
 }

--- a/src/Edi.TemplateEmail.Tests/MSTestSettings.cs
+++ b/src/Edi.TemplateEmail.Tests/MSTestSettings.cs
@@ -1,1 +1,0 @@
-﻿[assembly: Parallelize(Scope = ExecutionScope.MethodLevel)]

--- a/src/Edi.TemplateEmail.Tests/TemplateEngineTests.cs
+++ b/src/Edi.TemplateEmail.Tests/TemplateEngineTests.cs
@@ -1,16 +1,15 @@
 using System.Text;
+using Xunit;
 
 namespace Edi.TemplateEmail.Tests;
 
-[TestClass]
 public class TemplateEngineTests
 {
-    private TemplateMailMessage _templateMailMessage;
-    private TemplatePipeline _pipeline;
-    private TemplateEngine _templateEngine;
+    private readonly TemplateMailMessage _templateMailMessage;
+    private readonly TemplatePipeline _pipeline;
+    private readonly TemplateEngine _templateEngine;
 
-    [TestInitialize]
-    public void TestInitialize()
+    public TemplateEngineTests()
     {
         // Create a mock mail configuration for testing
         var mailConfig = new MailConfiguration
@@ -32,15 +31,15 @@ public class TemplateEngineTests
         _templateEngine = new TemplateEngine(_templateMailMessage, _pipeline);
     }
 
-    [TestMethod]
+    [Fact]
     public void Constructor_ShouldSetPropertiesCorrectly()
     {
         // Assert
-        Assert.AreSame(_pipeline, _templateEngine.Pipeline);
-        Assert.AreSame(_templateMailMessage, _templateEngine.TextProvider);
+        Assert.Same(_pipeline, _templateEngine.Pipeline);
+        Assert.Same(_templateMailMessage, _templateEngine.TextProvider);
     }
 
-    [TestMethod]
+    [Fact]
     public void Format_WithSimpleStringReplacement_ShouldReplaceCorrectly()
     {
         // Arrange
@@ -51,10 +50,10 @@ public class TemplateEngineTests
         string result = _templateEngine.Format(() => new StringBuilder(template));
 
         // Assert
-        Assert.AreEqual("Hello John Doe!", result);
+        Assert.Equal("Hello John Doe!", result);
     }
 
-    [TestMethod]
+    [Fact]
     public void Format_WithObjectPropertyReplacement_ShouldReplaceCorrectly()
     {
         // Arrange
@@ -66,10 +65,10 @@ public class TemplateEngineTests
         string result = _templateEngine.Format(() => new StringBuilder(template));
 
         // Assert
-        Assert.AreEqual("Hello John Doe!", result);
+        Assert.Equal("Hello John Doe!", result);
     }
 
-    [TestMethod]
+    [Fact]
     public void Format_WithMultipleEntities_ShouldReplaceAll()
     {
         // Arrange
@@ -83,10 +82,10 @@ public class TemplateEngineTests
         string result = _templateEngine.Format(() => new StringBuilder(template));
 
         // Assert
-        Assert.AreEqual("Dear John, welcome to ACME Corp!", result);
+        Assert.Equal("Dear John, welcome to ACME Corp!", result);
     }
 
-    [TestMethod]
+    [Fact]
     public void Format_WithNonExistentEntity_ShouldReplaceWithEmptyString()
     {
         // Arrange
@@ -96,10 +95,10 @@ public class TemplateEngineTests
         string result = _templateEngine.Format(() => new StringBuilder(template));
 
         // Assert
-        Assert.AreEqual("Hello !", result);
+        Assert.Equal("Hello !", result);
     }
 
-    [TestMethod]
+    [Fact]
     public void Format_WithNonExistentProperty_ShouldReplaceWithEmptyString()
     {
         // Arrange
@@ -111,10 +110,10 @@ public class TemplateEngineTests
         string result = _templateEngine.Format(() => new StringBuilder(template));
 
         // Assert
-        Assert.AreEqual("Hello !", result);
+        Assert.Equal("Hello !", result);
     }
 
-    [TestMethod]
+    [Fact]
     public void Format_WithNoTemplateTokens_ShouldReturnOriginalText()
     {
         // Arrange
@@ -124,10 +123,10 @@ public class TemplateEngineTests
         string result = _templateEngine.Format(() => new StringBuilder(template));
 
         // Assert
-        Assert.AreEqual(template, result);
+        Assert.Equal(template, result);
     }
 
-    [TestMethod]
+    [Fact]
     public void Format_WithEmptyString_ShouldReturnEmptyString()
     {
         // Arrange
@@ -137,10 +136,10 @@ public class TemplateEngineTests
         string result = _templateEngine.Format(() => new StringBuilder(template));
 
         // Assert
-        Assert.AreEqual("", result);
+        Assert.Equal("", result);
     }
 
-    [TestMethod]
+    [Fact]
     public void Format_WithSameTokenMultipleTimes_ShouldReplaceAllOccurrences()
     {
         // Arrange
@@ -151,10 +150,10 @@ public class TemplateEngineTests
         string result = _templateEngine.Format(() => new StringBuilder(template));
 
         // Assert
-        Assert.AreEqual("John said hello to John in the mirror.", result);
+        Assert.Equal("John said hello to John in the mirror.", result);
     }
 
-    [TestMethod]
+    [Fact]
     public void Format_WithComplexObject_ShouldReplaceCorrectly()
     {
         // Arrange
@@ -172,10 +171,10 @@ public class TemplateEngineTests
         string result = _templateEngine.Format(() => new StringBuilder(template));
 
         // Assert
-        Assert.AreEqual("Name: John Doe, Email: john.doe@example.com, Age: 30", result);
+        Assert.Equal("Name: John Doe, Email: john.doe@example.com, Age: 30", result);
     }
 
-    [TestMethod]
+    [Fact]
     public void Format_WithMalformedTokens_ShouldNotReplace()
     {
         // Arrange
@@ -186,10 +185,10 @@ public class TemplateEngineTests
         string result = _templateEngine.Format(() => new StringBuilder(template));
 
         // Assert
-        Assert.AreEqual("Hello {User Value} and {User.} and {.Value}!", result);
+        Assert.Equal("Hello {User Value} and {User.} and {.Value}!", result);
     }
 
-    [TestMethod]
+    [Fact]
     public void Format_WithNestedBraces_ShouldOnlyReplaceValidTokens()
     {
         // Arrange
@@ -200,10 +199,10 @@ public class TemplateEngineTests
         string result = _templateEngine.Format(() => new StringBuilder(template));
 
         // Assert
-        Assert.AreEqual("Hello {John} and John!", result);
+        Assert.Equal("Hello {John} and John!", result);
     }
 
-    [TestMethod]
+    [Fact]
     public void Format_WithNumericProperties_ShouldConvertToString()
     {
         // Arrange
@@ -215,10 +214,10 @@ public class TemplateEngineTests
         string result = _templateEngine.Format(() => new StringBuilder(template));
 
         // Assert
-        Assert.AreEqual("Count: 42, Average: 3.14", result);
+        Assert.Equal("Count: 42, Average: 3.14", result);
     }
 
-    [TestMethod]
+    [Fact]
     public void Format_WithBooleanProperties_ShouldConvertToString()
     {
         // Arrange
@@ -230,10 +229,10 @@ public class TemplateEngineTests
         string result = _templateEngine.Format(() => new StringBuilder(template));
 
         // Assert
-        Assert.AreEqual("Enabled: True, Visible: False", result);
+        Assert.Equal("Enabled: True, Visible: False", result);
     }
 
-    [TestMethod]
+    [Fact]
     public void Format_WithNullPropertyValue_ShouldReplaceWithEmptyString()
     {
         // Arrange
@@ -245,7 +244,7 @@ public class TemplateEngineTests
         string result = _templateEngine.Format(() => new StringBuilder(template));
 
         // Assert
-        Assert.AreEqual("Hello John !", result);
+        Assert.Equal("Hello John !", result);
     }
 
     // Helper classes for testing

--- a/src/Edi.TemplateEmail.Tests/TemplateMailMessageTests.cs
+++ b/src/Edi.TemplateEmail.Tests/TemplateMailMessageTests.cs
@@ -1,14 +1,13 @@
 using System.Globalization;
+using Xunit;
 
 namespace Edi.TemplateEmail.Tests;
 
-[TestClass]
 public class TemplateMailMessageTests
 {
-    private MailConfiguration _testMailConfiguration;
+    private readonly MailConfiguration _testMailConfiguration;
 
-    [TestInitialize]
-    public void TestInitialize()
+    public TemplateMailMessageTests()
     {
         _testMailConfiguration = new MailConfiguration
         {
@@ -50,46 +49,46 @@ public class TemplateMailMessageTests
         };
     }
 
-    [TestMethod]
+    [Fact]
     public void Constructor_WithNullMailConfig_ShouldSetLoadedToFalse()
     {
         // Act
         var templateMail = new TemplateMailMessage(null, "Welcome");
 
         // Assert
-        Assert.IsFalse(templateMail.Loaded);
-        Assert.IsNull(templateMail.Text);
-        Assert.IsFalse(templateMail.IsHtml);
-        Assert.IsNull(templateMail.Subject);
+        Assert.False(templateMail.Loaded);
+        Assert.Null(templateMail.Text);
+        Assert.False(templateMail.IsHtml);
+        Assert.Null(templateMail.Subject);
     }
 
-    [TestMethod]
+    [Fact]
     public void Constructor_WithValidMessageType_ShouldLoadCorrectMessage()
     {
         // Act
         var templateMail = new TemplateMailMessage(_testMailConfiguration, "Newsletter");
 
         // Assert
-        Assert.IsTrue(templateMail.Loaded);
-        Assert.AreEqual("Monthly Newsletter", templateMail.Subject);
-        Assert.AreEqual("<h2>Newsletter</h2><p>Here's what's new this month.</p>", templateMail.Text);
-        Assert.IsTrue(templateMail.IsHtml);
+        Assert.True(templateMail.Loaded);
+        Assert.Equal("Monthly Newsletter", templateMail.Subject);
+        Assert.Equal("<h2>Newsletter</h2><p>Here's what's new this month.</p>", templateMail.Text);
+        Assert.True(templateMail.IsHtml);
     }
 
-    [TestMethod]
+    [Fact]
     public void Constructor_WithNonExistentMessageType_ShouldSetLoadedToFalse()
     {
         // Act
         var templateMail = new TemplateMailMessage(_testMailConfiguration, "NonExistent");
 
         // Assert
-        Assert.IsFalse(templateMail.Loaded);
-        Assert.IsNull(templateMail.Text);
-        Assert.IsFalse(templateMail.IsHtml);
-        Assert.IsNull(templateMail.Subject);
+        Assert.False(templateMail.Loaded);
+        Assert.Null(templateMail.Text);
+        Assert.False(templateMail.IsHtml);
+        Assert.Null(templateMail.Subject);
     }
 
-    [TestMethod]
+    [Fact]
     public void Constructor_WithMatchingCulture_ShouldSelectCultureSpecificMessage()
     {
         // Arrange
@@ -102,10 +101,10 @@ public class TemplateMailMessageTests
             var templateMail = new TemplateMailMessage(_testMailConfiguration, "Welcome");
 
             // Assert
-            Assert.IsTrue(templateMail.Loaded);
-            Assert.AreEqual("Welcome to our service", templateMail.Subject);
-            Assert.AreEqual("<h1>Welcome!</h1><p>Thank you for joining us.</p>", templateMail.Text);
-            Assert.IsTrue(templateMail.IsHtml);
+            Assert.True(templateMail.Loaded);
+            Assert.Equal("Welcome to our service", templateMail.Subject);
+            Assert.Equal("<h1>Welcome!</h1><p>Thank you for joining us.</p>", templateMail.Text);
+            Assert.True(templateMail.IsHtml);
         }
         finally
         {
@@ -113,7 +112,7 @@ public class TemplateMailMessageTests
         }
     }
 
-    [TestMethod]
+    [Fact]
     public void Constructor_WithNonMatchingCulture_ShouldSelectFirstMessage()
     {
         // Arrange
@@ -126,10 +125,10 @@ public class TemplateMailMessageTests
             var templateMail = new TemplateMailMessage(_testMailConfiguration, "Welcome");
 
             // Assert
-            Assert.IsTrue(templateMail.Loaded);
-            Assert.AreEqual("Welcome to our service", templateMail.Subject);
-            Assert.AreEqual("<h1>Welcome!</h1><p>Thank you for joining us.</p>", templateMail.Text);
-            Assert.IsTrue(templateMail.IsHtml);
+            Assert.True(templateMail.Loaded);
+            Assert.Equal("Welcome to our service", templateMail.Subject);
+            Assert.Equal("<h1>Welcome!</h1><p>Thank you for joining us.</p>", templateMail.Text);
+            Assert.True(templateMail.IsHtml);
         }
         finally
         {
@@ -137,7 +136,7 @@ public class TemplateMailMessageTests
         }
     }
 
-    [TestMethod]
+    [Fact]
     public void Constructor_WithFrenchCulture_ShouldSelectFrenchMessage()
     {
         // Arrange
@@ -150,10 +149,10 @@ public class TemplateMailMessageTests
             var templateMail = new TemplateMailMessage(_testMailConfiguration, "Welcome");
 
             // Assert
-            Assert.IsTrue(templateMail.Loaded);
-            Assert.AreEqual("Bienvenue ид notre service", templateMail.Subject);
-            Assert.AreEqual("Bienvenue! Merci de nous avoir rejoint.", templateMail.Text);
-            Assert.IsFalse(templateMail.IsHtml);
+            Assert.True(templateMail.Loaded);
+            Assert.Equal("Bienvenue ид notre service", templateMail.Subject);
+            Assert.Equal("Bienvenue! Merci de nous avoir rejoint.", templateMail.Text);
+            Assert.False(templateMail.IsHtml);
         }
         finally
         {
@@ -161,33 +160,33 @@ public class TemplateMailMessageTests
         }
     }
 
-    [TestMethod]
+    [Fact]
     public void Constructor_WithEmptyMessageType_ShouldSetLoadedToFalse()
     {
         // Act
         var templateMail = new TemplateMailMessage(_testMailConfiguration, "");
 
         // Assert
-        Assert.IsFalse(templateMail.Loaded);
-        Assert.IsNull(templateMail.Text);
-        Assert.IsFalse(templateMail.IsHtml);
-        Assert.IsNull(templateMail.Subject);
+        Assert.False(templateMail.Loaded);
+        Assert.Null(templateMail.Text);
+        Assert.False(templateMail.IsHtml);
+        Assert.Null(templateMail.Subject);
     }
 
-    [TestMethod]
+    [Fact]
     public void Constructor_WithNullMessageType_ShouldSetLoadedToFalse()
     {
         // Act
         var templateMail = new TemplateMailMessage(_testMailConfiguration, null);
 
         // Assert
-        Assert.IsFalse(templateMail.Loaded);
-        Assert.IsNull(templateMail.Text);
-        Assert.IsFalse(templateMail.IsHtml);
-        Assert.IsNull(templateMail.Subject);
+        Assert.False(templateMail.Loaded);
+        Assert.Null(templateMail.Text);
+        Assert.False(templateMail.IsHtml);
+        Assert.Null(templateMail.Subject);
     }
 
-    [TestMethod]
+    [Fact]
     public void Constructor_WithEmptyMailMessages_ShouldSetLoadedToFalse()
     {
         // Arrange
@@ -200,13 +199,13 @@ public class TemplateMailMessageTests
         var templateMail = new TemplateMailMessage(emptyConfig, "Welcome");
 
         // Assert
-        Assert.IsFalse(templateMail.Loaded);
-        Assert.IsNull(templateMail.Text);
-        Assert.IsFalse(templateMail.IsHtml);
-        Assert.IsNull(templateMail.Subject);
+        Assert.False(templateMail.Loaded);
+        Assert.Null(templateMail.Text);
+        Assert.False(templateMail.IsHtml);
+        Assert.Null(templateMail.Subject);
     }
 
-    [TestMethod]
+    [Fact]
     public void Constructor_WithNullMailMessages_ShouldThrowException()
     {
         // Arrange
@@ -216,11 +215,11 @@ public class TemplateMailMessageTests
         };
 
         // Act & Assert
-        Assert.ThrowsExactly<NullReferenceException>(() => 
+        Assert.Throws<NullReferenceException>(() =>
             new TemplateMailMessage(configWithNullMessages, "Welcome"));
     }
 
-    [TestMethod]
+    [Fact]
     public void Constructor_WithCaseInsensitiveCultureMatch_ShouldSelectCorrectMessage()
     {
         // Arrange
@@ -233,9 +232,9 @@ public class TemplateMailMessageTests
             var templateMail = new TemplateMailMessage(_testMailConfiguration, "Welcome");
 
             // Assert
-            Assert.IsTrue(templateMail.Loaded);
-            Assert.AreEqual("Welcome to our service", templateMail.Subject);
-            Assert.IsTrue(templateMail.IsHtml);
+            Assert.True(templateMail.Loaded);
+            Assert.Equal("Welcome to our service", templateMail.Subject);
+            Assert.True(templateMail.IsHtml);
         }
         finally
         {
@@ -243,20 +242,20 @@ public class TemplateMailMessageTests
         }
     }
 
-    [TestMethod]
+    [Fact]
     public void Constructor_WithMessageHavingNullOrEmptyCulture_ShouldStillBeSelectable()
     {
         // Act
         var templateMail = new TemplateMailMessage(_testMailConfiguration, "Notification");
 
         // Assert
-        Assert.IsTrue(templateMail.Loaded);
-        Assert.AreEqual("System Notification", templateMail.Subject);
-        Assert.AreEqual("This is a system notification.", templateMail.Text);
-        Assert.IsFalse(templateMail.IsHtml);
+        Assert.True(templateMail.Loaded);
+        Assert.Equal("System Notification", templateMail.Subject);
+        Assert.Equal("This is a system notification.", templateMail.Text);
+        Assert.False(templateMail.IsHtml);
     }
 
-    [TestMethod]
+    [Fact]
     public void Constructor_WithMultipleMessagesOfSameTypeAndNoCultureMatch_ShouldSelectFirst()
     {
         // Arrange
@@ -292,10 +291,10 @@ public class TemplateMailMessageTests
             var templateMail = new TemplateMailMessage(configWithMultiple, "Test");
 
             // Assert
-            Assert.IsTrue(templateMail.Loaded);
-            Assert.AreEqual("First Subject", templateMail.Subject);
-            Assert.AreEqual("First Body", templateMail.Text);
-            Assert.IsFalse(templateMail.IsHtml);
+            Assert.True(templateMail.Loaded);
+            Assert.Equal("First Subject", templateMail.Subject);
+            Assert.Equal("First Body", templateMail.Text);
+            Assert.False(templateMail.IsHtml);
         }
         finally
         {
@@ -303,20 +302,20 @@ public class TemplateMailMessageTests
         }
     }
 
-    [TestMethod]
+    [Fact]
     public void Properties_ShouldHaveCorrectGetters()
     {
         // Arrange
         var templateMail = new TemplateMailMessage(_testMailConfiguration, "Newsletter");
 
         // Act & Assert
-        Assert.IsNotNull(templateMail.Text);
-        Assert.IsNotNull(templateMail.Subject);
-        Assert.IsTrue(templateMail.IsHtml);
-        Assert.IsTrue(templateMail.Loaded);
+        Assert.NotNull(templateMail.Text);
+        Assert.NotNull(templateMail.Subject);
+        Assert.True(templateMail.IsHtml);
+        Assert.True(templateMail.Loaded);
     }
 
-    [TestMethod]
+    [Fact]
     public void Properties_ShouldAllowSetting()
     {
         // Arrange
@@ -330,9 +329,9 @@ public class TemplateMailMessageTests
         templateMail.IsHtml = false;
 
         // Assert
-        Assert.AreEqual(newText, templateMail.Text);
-        Assert.AreEqual(newSubject, templateMail.Subject);
-        Assert.IsFalse(templateMail.IsHtml);
-        Assert.IsTrue(templateMail.Loaded); // Loaded property should be read-only
+        Assert.Equal(newText, templateMail.Text);
+        Assert.Equal(newSubject, templateMail.Subject);
+        Assert.False(templateMail.IsHtml);
+        Assert.True(templateMail.Loaded); // Loaded property should be read-only
     }
 }


### PR DESCRIPTION
Replaces MSTest attributes and assertions with xUnit equivalents in all test files. Removes MSTest-specific configuration and dependencies from the test project, and updates project references to use xUnit and coverlet for test running and coverage.